### PR TITLE
fix lost environment and long startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Authors:
 # Xiangmin Jiao <xmjiao@gmail.com>
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 LABEL maintainer Xiangmin Jiao <xmjiao@gmail.com>
 
 ARG DOCKER_LANG=en_US
@@ -31,7 +31,7 @@ RUN apt-get update && \
         language-pack-en && \
     locale-gen $LANG && \
     dpkg-reconfigure -f noninteractive locales && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
         less \
         vim \
@@ -42,7 +42,7 @@ RUN apt-get update && \
         man \
         sudo \
         rsync \
-        bsdtar \
+        tar \
         net-tools \
         gpg-agent \
         inetutils-ping \
@@ -56,7 +56,6 @@ RUN apt-get update && \
         dbus-x11 \
         \
         openssh-server \
-        python \
         python3 \
         python3-distutils \
         python3-tk \
@@ -93,14 +92,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install websokify and noVNC
-RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
-    python2 get-pip.py && \
-    pip2 install --no-cache-dir \
+RUN curl -O https://bootstrap.pypa.io/pip/3.5/get-pip.py && \
+    python3 get-pip.py && \
+    /usr/bin/python3 -m pip install --upgrade pip && \
+    pip3 install --no-cache-dir \
         setuptools && \
-    pip2 install -U https://github.com/novnc/websockify/archive/60acf3c.tar.gz && \
+    pip3 install -U https://github.com/novnc/websockify/archive/refs/tags/v0.10.0.tar.gz && \
     mkdir /usr/local/noVNC && \
     curl -s -L https://github.com/x11vnc/noVNC/archive/master.tar.gz | \
-         bsdtar zxf - -C /usr/local/noVNC --strip-components 1 && \
+         tar zxf - -C /usr/local/noVNC --strip-components 1 && \
     rm -rf /tmp/* /var/tmp/*
 
 # Install x11vnc from source
@@ -108,21 +108,21 @@ RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
 # https://bugs.launchpad.net/ubuntu/+source/x11vnc/+bug/1686084
 # Also, fix issue with Shift-Tab not working
 # https://askubuntu.com/questions/839842/vnc-pressing-shift-tab-tab-only
-RUN apt-get update && \
-    apt-get install -y libxtst-dev libssl-dev libjpeg-dev && \
-    \
-    mkdir -p /tmp/x11vnc-0.9.14 && \
-    curl -s -L http://x11vnc.sourceforge.net/dev/x11vnc-0.9.14-dev.tar.gz | \
-        bsdtar zxf - -C /tmp/x11vnc-0.9.14 --strip-components 1 && \
-    cd /tmp/x11vnc-0.9.14 && \
-    ./configure --prefix=/usr/local CFLAGS='-O2 -fno-stack-protector -Wall' && \
-    make && \
-    make install && \
-    perl -e 's/,\s*ISO_Left_Tab//g' -p -i /usr/share/X11/xkb/symbols/pc && \
-    apt-get -y remove libxtst-dev libssl-dev libjpeg-dev && \
-    apt-get -y autoremove && \
-    ldconfig && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+#RUN apt-get update && \
+#    apt-get install -y libxtst-dev libssl-dev libjpeg-dev && \
+#    \
+#    mkdir -p /tmp/x11vnc-0.9.14 && \
+#    curl -s -L http://x11vnc.sourceforge.net/dev/x11vnc-0.9.14-dev.tar.gz | \
+#        tar zxf - -C /tmp/x11vnc-0.9.14 --strip-components 1 && \
+#    cd /tmp/x11vnc-0.9.14 && \
+#    ./configure --prefix=/usr/local CFLAGS='-O2 -fno-stack-protector -Wall' && \
+#    make && \
+#    make install && \
+#    perl -e 's/,\s*ISO_Left_Tab//g' -p -i /usr/share/X11/xkb/symbols/pc && \
+#    apt-get -y remove libxtst-dev libssl-dev libjpeg-dev && \
+#    apt-get -y autoremove && \
+#    ldconfig && \
+#    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ########################################################
 # Customization for user and location

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN curl -O https://bootstrap.pypa.io/pip/3.5/get-pip.py && \
 # Set up user so that we do not run as root in DOCKER
 ENV DOCKER_USER=ubuntu \
     DOCKER_UID=1000 \
-    DOCKER_GID=100 \
+    DOCKER_GID=1000 \
     DOCKER_SHELL=/bin/zsh
 
 ENV DOCKER_GROUP=$DOCKER_USER \

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,8 @@ RUN curl -O https://bootstrap.pypa.io/pip/3.5/get-pip.py && \
 ########################################################
 # Set up user so that we do not run as root in DOCKER
 ENV DOCKER_USER=ubuntu \
-    DOCKER_UID=9999 \
-    DOCKER_GID=9999 \
+    DOCKER_UID=1000 \
+    DOCKER_GID=100 \
     DOCKER_SHELL=/bin/zsh
 
 ENV DOCKER_GROUP=$DOCKER_USER \
@@ -166,5 +166,5 @@ WORKDIR $DOCKER_HOME
 ENV DOCKER_CMD=start_vnc
 
 USER root
-ENTRYPOINT ["/sbin/my_init", "--quiet", "--", "/sbin/setuser", "ubuntu"]
+ENTRYPOINT ["/sbin/my_init", "--", "/sbin/setuser", "ubuntu"]
 CMD ["$DOCKER_CMD"]

--- a/image/etc/my_init.d/init-home.sh
+++ b/image/etc/my_init.d/init-home.sh
@@ -14,11 +14,12 @@ fi
 if [ -e '/etc/container_environment.sh' ]; then
     source /etc/container_environment.sh
 fi
-find $DOCKER_HOME -maxdepth 1 -type d | sed "1d" | xargs chown $DOCKER_USER:$DOCKER_GROUP 2> /dev/null || true
+if [ ! -z "$UPDATE_HOME_WITH_UID" ]; then
+    find $DOCKER_HOME -maxdepth 1 -type d | sed "1d" | xargs chown $DOCKER_USER:$DOCKER_GROUP 2> /dev/null || true
 
-# It is important for $HOME/.ssh to have correct ownership
-chown -R $DOCKER_USER $DOCKER_HOME/.ssh
-
+    # It is important for $HOME/.ssh to have correct ownership
+    chown -R $DOCKER_USER $DOCKER_HOME/.ssh
+fi
 # Initialize config directory
 [ -d $DOCKER_HOME/.config/mozilla ] || cp -r /etc/X11/mozilla $DOCKER_HOME/.config/mozilla
 

--- a/image/sbin/my_init
+++ b/image/sbin/my_init
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/image/sbin/my_init
+++ b/image/sbin/my_init
@@ -12,6 +12,10 @@ import stat
 import sys
 import time
 
+START_ENV = {}
+for key in os.environ.keys():
+    START_ENV[key] = os.environ[key]
+
 ENV_INIT_DIRECTORY = os.environ.get('ENV_INIT_DIRECTORY', '/etc/my_init.d')
 
 KILL_PROCESS_TIMEOUT = int(os.environ.get('KILL_PROCESS_TIMEOUT', 5))
@@ -97,6 +101,8 @@ def import_envvars(clear_existing_environment=True, override_existing_environmen
         new_env[name] = value
     if clear_existing_environment:
         os.environ.clear()
+        for key in START_ENV.keys():
+            os.environ[key] = START_ENV[key]
     for name, value in new_env.items():
         if override_existing_environment or name not in os.environ:
             os.environ[name] = value

--- a/image/sbin/setuser
+++ b/image/sbin/setuser
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 Copyright (c) 2013-2015 Phusion Holding B.V.


### PR DESCRIPTION
* Environment are lost if os.environ.clear is called for init scripts. Therefore start environment is stored.
* chown in init-home will take a long time for every start if shared home folder have lot of entries, therefore a env parameter UPDATE_HOME_WITH_UID will trigger the behaviour 